### PR TITLE
feat: add api endpoints for partner data

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,6 +1,6 @@
 from flask import Flask, jsonify, request
 import time
-from grafana import get_for
+from grafana import get_for, get_partners_for
 
 app = Flask(__name__)
 
@@ -30,6 +30,22 @@ def tvl_network(network):
 
     key = f"tvl_{network.lower()}"
     res = get_for(key, _get_ts(), UNIT_USD)
+    return jsonify(res)
+
+
+@app.route("/partners/total", methods=['GET'])
+def partners_total():
+    return jsonify(get_for('partners_total', _get_ts(), UNIT_USD))
+
+
+@app.route("/partners/count", methods=['GET'])
+def partners_count():
+    return jsonify(get_for('partners_count', _get_ts(), ''))
+
+
+@app.route("/partners/<partner>/<param>", methods=['GET'])
+def partners_indiv(partner, param):
+    res = get_partners_for(partner, param, _get_ts(), UNIT_USD)
     return jsonify(res)
 
 


### PR DESCRIPTION
## Description

This PR aims to add the endpoints for querying partner-related info, as mentioned in https://github.com/yearn/yearn-exporter/pull/349 and https://github.com/yearn/yearn-exporter/pull/359.

The new endpoints to be added are the following:
- `/partners/total`: returns the total fees to be paid out to-date, measured in USD value
- `/partners/count`: returns the number of partners to-date
- `/partners/<partner>/<param>`, where the available params are noted in https://github.com/mariuspod/yearn-exporter-api/commit/59017bbed9af5445f5be75b25d52ea53dff08221#diff-706096ff8c6d07cfc0fc5dcefdd281422d19a7df2d373fe3fb818bfb0ba633d9R109: they should return a json that contains info for each vault their wrappers correspond to

## How Has This Been Tested?

Has been checked by running a local version of the yearn-exporter in the PR https://github.com/yearn/yearn-exporter/pull/359, and running `docker-compose` from this repository.