### PR TITLE
Fix/tvl

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.7"
 
 services:
   yearn-exporter-api:
+    build: .
     image: ghcr.io/yearn/yearn-exporter-api:${DOCKER_TAG:-latest}
     ports:
       - 127.0.0.1:${FLASK_RUN_PORT:-5000}:${FLASK_RUN_PORT:-5000}

--- a/grafana.py
+++ b/grafana.py
@@ -54,7 +54,11 @@ def get_for(key, ts, unit):
 
 
 def _ds_parse_value(response):
-    data = response['results']['A']['frames'][0]['data']
+    frames = response['results']['A']['frames']
+    if len(frames) == 0:
+      return 0
+
+    data = frames[0]['data']
     values = data['values'][1]
     value = 0
     for i in range(len(values)-1, -1, -1):


### PR DESCRIPTION
There's an issue for the `/tvl` route when a single network does not return any values.

This PR adds one more check before accessing the response list so the server doesn't crash with 500.
Also added a docker build target because `make build` didn't work for me without it.